### PR TITLE
[feat] --list-fields command

### DIFF
--- a/logshare.go
+++ b/logshare.go
@@ -142,6 +142,12 @@ func (c *Client) GetFromTimestamp(zoneID string, start int64, end int64, count i
 	return c.request(url)
 }
 
+// FetchFieldNames fetches the names of the available log fields.
+func (c *Client) FetchFieldNames(zoneID string) (*Meta, error) {
+	url := fmt.Sprintf("%s/zones/%s/logs/received/fields", c.endpoint, zoneID)
+	return c.request(url)
+}
+
 func (c *Client) request(url string) (*Meta, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
Adds the `--list-fields` CLI flag to show the available fields under the [new /received logging endpoint](https://support.cloudflare.com/hc/en-us/articles/115001052112).

