### PR TITLE
[feat] Add Error Context to HTTP 400 errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ matrix:
   include:
     - go: 1.x
       env: LATEST=true
-    - go: 1.7
-    - go: 1.8
-    - go: 1.9
+    - go: 1.7.x
+    - go: 1.8.x
+    - go: 1.9.x
+    - go: 1.10.x
     - go: tip
   allow_failures:
     - go: tip


### PR DESCRIPTION
e.g.

```sh
logshare-cli --api-email="you@example.com" --api-key="$key" \ 
  --zone-name="example.com" --start-time=`mins-ago 85` --end-time=`mins-ago 10`
[logshare-cli] 09:18:10 failed to fetch via timestamp: HTTP status 400: request failed: bad query: error parsing time: invalid time range: too long
```

Addresses #23 