### PR TITLE
[fix] Allow 0.1% sampling of logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ leverage [`jq`](https://stedolan.github.io/jq/) to parse log output.
 By default, the Log Share endpoint provides logs with Unix nanosecond timestamps and the full set of available logs.
 
 * Pass the `timestamp-format=` flag with one of `unix`, `unixnano` (default) or `rfc3339` to customize the timestamps.
-* Pass the `sample=` flag with a value between `0.1` (10%) or `0.9` (90%) to retrieve a random sample of logs.
+* Pass the `sample=` flag with a value between `0.001` (0.1%) or `1` (100%) to retrieve a random sample of logs.
 
 #### Distribution of Edge (client-facing) Response Status Codes
 

--- a/logshare.go
+++ b/logshare.go
@@ -135,7 +135,7 @@ func (c *Client) buildURL(zoneID string, params url.Values) (*url.URL, error) {
 	}
 
 	if c.sample != 0.0 {
-		params.Set("sample", strconv.FormatFloat(c.sample, 'f', 1, 64))
+		params.Set("sample", strconv.FormatFloat(c.sample, 'f', 3, 64))
 	}
 
 	if c.timestampFormat != "" {

--- a/logshare.go
+++ b/logshare.go
@@ -54,7 +54,7 @@ type Options struct {
 	ByReceived bool
 	// Which timestamp format to use: one of "unix", "unixnano", "rfc3339"
 	TimestampFormat string
-	// Whether to only retrieve a sample of logs (0.1 to 0.9)
+	// Whether to only retrieve a sample of logs (0.001 to 1)
 	Sample float64
 	// The fields to return in the log responses
 	Fields []string


### PR DESCRIPTION
The log share REST API allows sampling rates >= 0.001 however when I try to use this library with a `0.01` sample value (1%) I received the following error:
```
2018/08/30 21:20:39 HTTP status 400: request failed: bad query: error parsing sample parameter: sample must be >= 0.001000
```

Looks like the float-->string conversion only allowed 1 digit when it should be 3. With 1, the conversion was rounding `0.01` down to `0`.

Signed-off-by: Derek Argueta <dereka@pinterest.com>