### PR TITLE
Drop Go 1.7/1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
   include:
     - go: 1.x
       env: LATEST=true
-    - go: 1.7.x
-    - go: 1.8.x
     - go: 1.9.x
     - go: 1.10.x
     - go: tip


### PR DESCRIPTION
These versions are getting a bit long in the tooth and difficult to
maintain. Instead of vendoring, just drop 1.7/1.8 from CI.

Fixes https://travis-ci.org/cloudflare/logshare/jobs/457245609
Fixes https://travis-ci.org/cloudflare/logshare/jobs/457245610