### PR TITLE
Adding go 1.11.x and deleting 1.9.x from build versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ matrix:
   include:
     - go: 1.x
       env: LATEST=true
-    - go: 1.9.x
     - go: 1.10.x
+    - go: 1.11.x
     - go: tip
   allow_failures:
     - go: tip


### PR DESCRIPTION
Adding 1.11.x to the build list and removing 1.9.x.